### PR TITLE
Change migration command in readme to use `db:migrate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker compose up
 5.  Run Database Migrations:
 
 ```sh
-npm run migrate
+npm run db:migrate
 ```
 
 6.  Start the dev server


### PR DESCRIPTION
Just a trivial change to the readme, using the `db:migrate` syntax for running the database migration.