### PR TITLE
feat: implement API change requests

### DIFF
--- a/DOCS/v2-api-endpoints.md
+++ b/DOCS/v2-api-endpoints.md
@@ -4,6 +4,20 @@
 
 All V2 endpoints use UUID-based identifiers and the "verified" field pattern instead of "approved". Authentication is required for most endpoints via Bearer token.
 
+## Recent Updates (api-improvements branch)
+
+### Changes Made:
+- **Musical**: Added optional `posterUrl` field to POST and PUT endpoints
+- **Performance**: Added optional `date` field to POST and PUT endpoints  
+- **Casting**: 
+  - Added **required** `performanceId` field to all endpoints
+  - POST response now returns only `{"id": "casting-uuid"}` 
+  - Removed `verified` field completely
+  - Removed pending query parameter and verify endpoint
+  - GET `/casting` now returns all castings (no filtering)
+
+---
+
 ## Authentication Endpoints
 
 ### Users
@@ -206,7 +220,8 @@ curl -X POST http://localhost:3000/v2/musical \
 -d '{
   "title": "Hamilton",
   "composer": "Lin-Manuel Miranda",
-  "lyricist": "Lin-Manuel Miranda"
+  "lyricist": "Lin-Manuel Miranda",
+  "posterUrl": "https://example.com/hamilton-poster.jpg"
 }'
 ```
 
@@ -225,7 +240,8 @@ curl -X PUT http://localhost:3000/v2/musical/:id \
 -d '{
   "title": "Updated Musical Title",
   "composer": "Updated Composer",
-  "lyricist": "Updated Lyricist"
+  "lyricist": "Updated Lyricist",
+  "posterUrl": "https://example.com/updated-poster.jpg"
 }'
 ```
 
@@ -304,17 +320,10 @@ curl -X POST http://localhost:3000/v2/role/:id/verify \
 
 ## Casting Endpoints
 
-#### Get All Verified Castings
+#### Get All Castings
 
 ```bash
 curl -X GET http://localhost:3000/v2/casting
-```
-
-#### Get Pending Castings (Admin Only)
-
-```bash
-curl -X GET "http://localhost:3000/v2/casting?pending=true" \
--H "Authorization: Bearer YOUR_ACCESS_TOKEN"
 ```
 
 #### Create Casting
@@ -325,8 +334,16 @@ curl -X POST http://localhost:3000/v2/casting \
 -H "Content-Type: application/json" \
 -d '{
   "actorId": "uuid-of-actor",
-  "roleId": "uuid-of-role"
+  "roleId": "uuid-of-role",
+  "performanceId": "uuid-of-performance"
 }'
+```
+
+**Response:**
+```json
+{
+  "id": "uuid-of-created-casting"
+}
 ```
 
 #### Get Casting by ID
@@ -343,7 +360,8 @@ curl -X PUT http://localhost:3000/v2/casting/:id \
 -H "Content-Type: application/json" \
 -d '{
   "actorId": "uuid-of-actor",
-  "roleId": "uuid-of-role"
+  "roleId": "uuid-of-role",
+  "performanceId": "uuid-of-performance"
 }'
 ```
 
@@ -351,13 +369,6 @@ curl -X PUT http://localhost:3000/v2/casting/:id \
 
 ```bash
 curl -X DELETE http://localhost:3000/v2/casting/:id \
--H "Authorization: Bearer YOUR_ACCESS_TOKEN"
-```
-
-#### Verify Casting (Admin Only)
-
-```bash
-curl -X POST http://localhost:3000/v2/casting/:id/verify \
 -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
 ```
 
@@ -385,6 +396,7 @@ curl -X POST http://localhost:3000/v2/performance \
 -H "Content-Type: application/json" \
 -d '{
   "musicalId": "uuid-of-musical",
+  "date": "2024-12-25",
   "notes": "Amazing show!",
   "posterUrl": "https://example.com/poster.jpg"
 }'
@@ -405,6 +417,7 @@ curl -X PUT http://localhost:3000/v2/performance/:id \
 -H "Content-Type: application/json" \
 -d '{
   "musicalId": "uuid-of-musical",
+  "date": "2024-12-26",
   "notes": "Updated notes",
   "posterUrl": "https://example.com/updated-poster.jpg"
 }'

--- a/src/drizzle/migrations/0001_ordinary_human_cannonball.sql
+++ b/src/drizzle/migrations/0001_ordinary_human_cannonball.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "casting" ADD COLUMN "performance_id" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "musical" ADD COLUMN "poster_url" varchar(255);--> statement-breakpoint
+ALTER TABLE "performance" ADD COLUMN "date" date;--> statement-breakpoint
+ALTER TABLE "casting" ADD CONSTRAINT "casting_performance_id_performance_id_fk" FOREIGN KEY ("performance_id") REFERENCES "public"."performance"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "casting" DROP COLUMN "verified";

--- a/src/drizzle/migrations/meta/0001_snapshot.json
+++ b/src/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,564 @@
+{
+  "id": "ebae2e38-d31f-4195-83db-46c91c174767",
+  "prevId": "35dafd09-4778-40c6-9f5b-ac1198434647",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.casting": {
+      "name": "casting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performance_id": {
+          "name": "performance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "casting_role_id_role_id_fk": {
+          "name": "casting_role_id_role_id_fk",
+          "tableFrom": "casting",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "casting_actor_id_actor_id_fk": {
+          "name": "casting_actor_id_actor_id_fk",
+          "tableFrom": "casting",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "casting_performance_id_performance_id_fk": {
+          "name": "casting_performance_id_performance_id_fk",
+          "tableFrom": "casting",
+          "tableTo": "performance",
+          "columnsFrom": [
+            "performance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.musical": {
+      "name": "musical",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "composer": {
+          "name": "composer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lyricist": {
+          "name": "lyricist",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.performance": {
+      "name": "performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "musical_id": {
+          "name": "musical_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "performance_musical_id_musical_id_fk": {
+          "name": "performance_musical_id_musical_id_fk",
+          "tableFrom": "performance",
+          "tableTo": "musical",
+          "columnsFrom": [
+            "musical_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "performance_user_id_users_id_fk": {
+          "name": "performance_user_id_users_id_fk",
+          "tableFrom": "performance",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.production": {
+      "name": "production",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "musical_id": {
+          "name": "musical_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "production_musical_id_musical_id_fk": {
+          "name": "production_musical_id_musical_id_fk",
+          "tableFrom": "production",
+          "tableTo": "musical",
+          "columnsFrom": [
+            "musical_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "musical_id": {
+          "name": "musical_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_musical_id_musical_id_fk": {
+          "name": "role_musical_id_musical_id_fk",
+          "tableFrom": "role",
+          "tableTo": "musical",
+          "columnsFrom": [
+            "musical_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theater": {
+      "name": "theater",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_setup_complete": {
+          "name": "initial_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "emailUniqueIndex": {
+          "name": "emailUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/migrations/meta/_journal.json
+++ b/src/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1756941534066,
       "tag": "0000_watery_wallflower",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1757184186142,
+      "tag": "0001_ordinary_human_cannonball",
+      "breakpoints": true
     }
   ]
 }

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -74,6 +74,7 @@ export const MusicalTable = pgTable("musical", {
   composer: varchar("composer", { length: 255 }).notNull(),
   lyricist: varchar("lyricist", { length: 255 }).notNull(),
   title: varchar("title", { length: 255 }).notNull(),
+  posterUrl: varchar("poster_url", { length: 255 }),
   verified: boolean("verified").default(false).notNull(),
 });
 
@@ -85,6 +86,7 @@ export const PerformanceTable = pgTable("performance", {
   userId: uuid("user_id")
     .notNull()
     .references(() => UserTable.id),
+  date: date("date", { mode: "date" }),
   notes: text("notes"),
   posterUrl: varchar("poster_url", { length: 255 }),
 });
@@ -97,7 +99,9 @@ export const CastingTable = pgTable("casting", {
   actorId: uuid("actor_id")
     .notNull()
     .references(() => ActorTable.id),
-  verified: boolean("verified").default(false).notNull(),
+  performanceId: uuid("performance_id")
+    .notNull()
+    .references(() => PerformanceTable.id),
 });
 
 export const ProductionTable = pgTable("production", {

--- a/src/v2/routes/castings.ts.backup
+++ b/src/v2/routes/castings.ts.backup
@@ -4,7 +4,7 @@ import { Validator } from "../../lib/validator.js";
 import { db } from "../../drizzle/db.js";
 import { SERVER_ERROR } from "../../lib/errors.js";
 import { eq } from "drizzle-orm";
-import { ensureAuthenticated } from "../../lib/auth.js";
+import { ensureAdmin, ensureAuthenticated } from "../../lib/auth.js";
 import { validate as validateUuid } from "uuid";
 
 export const castingRouter = Router();
@@ -14,11 +14,34 @@ castingRouter.post("/", ensureAuthenticated, createCastingHandler);
 castingRouter.get("/:id", getCastingByIdHandler);
 castingRouter.put("/:id", ensureAuthenticated, updateCastingHandler);
 castingRouter.delete("/:id", ensureAuthenticated, deleteCastingHandler);
+castingRouter.post(
+  "/:id/verify",
+  ensureAuthenticated,
+  ensureAdmin,
+  verifyCastingHandler
+);
 
 async function getAllCastingsHandler(req: Request, res: Response) {
   try {
-    // Get all castings (no verified filtering as requested)
-    const result = await db.select().from(CastingTable);
+    const { pending } = req.query;
+
+    if (pending === "true") {
+      // Admin-only: show pending castings
+      if (req.user?.role !== "admin") {
+        res.status(403).json({ error: "Access denied" });
+        return;
+      }
+      const result = await db.query.CastingTable.findMany({
+        where: eq(CastingTable.verified, false),
+      });
+      res.status(200).json(result);
+      return;
+    }
+
+    // Public: show verified castings
+    const result = await db.query.CastingTable.findMany({
+      where: eq(CastingTable.verified, true),
+    });
     res.status(200).json(result);
   } catch (error) {
     console.error("Error in getAllCastingsHandler:", error);
@@ -29,14 +52,13 @@ async function getAllCastingsHandler(req: Request, res: Response) {
 type CreateCastingBodyParams = {
   roleId: string;
   actorId: string;
-  performanceId: string;
 };
 
 async function createCastingHandler(
   req: Request<{}, {}, CreateCastingBodyParams>,
   res: Response
 ) {
-  const { roleId, actorId, performanceId } = req.body;
+  const { roleId, actorId } = req.body;
   const validator = new Validator();
 
   try {
@@ -50,15 +72,6 @@ async function createCastingHandler(
       validator.check(validateUuid(actorId), "actorId", "must be a valid UUID");
     }
 
-    validator.check(!!performanceId, "performanceId", "is required");
-    if (performanceId) {
-      validator.check(
-        validateUuid(performanceId),
-        "performanceId",
-        "must be a valid UUID"
-      );
-    }
-
     if (!validator.valid) {
       res.status(400).json({ errors: validator.errors });
       return;
@@ -69,14 +82,13 @@ async function createCastingHandler(
       .values({
         roleId,
         actorId,
-        performanceId,
       })
       .returning({ id: CastingTable.id });
 
     if (newCasting.length > 0) {
-      // Return only the casting ID as requested
       res.status(201).json({
-        id: newCasting[0]!.id,
+        message: "Casting created successfully",
+        casting: { id: newCasting[0]!.id, roleId, actorId },
       });
     } else {
       res.status(500).json({ error: "Failed to create casting" });
@@ -132,7 +144,6 @@ async function getCastingByIdHandler(
 type UpdateCastingBodyParams = {
   roleId?: string;
   actorId?: string;
-  performanceId?: string;
 };
 
 async function updateCastingHandler(
@@ -140,7 +151,7 @@ async function updateCastingHandler(
   res: Response
 ) {
   const { id } = req.params;
-  const { roleId, actorId, performanceId } = req.body;
+  const { roleId, actorId } = req.body;
   const validator = new Validator();
 
   try {
@@ -155,14 +166,6 @@ async function updateCastingHandler(
 
     if (actorId) {
       validator.check(validateUuid(actorId), "actorId", "must be a valid UUID");
-    }
-
-    if (performanceId) {
-      validator.check(
-        validateUuid(performanceId),
-        "performanceId",
-        "must be a valid UUID"
-      );
     }
 
     if (!validator.valid) {
@@ -182,20 +185,13 @@ async function updateCastingHandler(
     const updateData: Partial<{
       roleId: string;
       actorId: string;
-      performanceId: string;
     }> = {};
 
     if (roleId) updateData.roleId = roleId;
     if (actorId) updateData.actorId = actorId;
-    if (performanceId) updateData.performanceId = performanceId;
 
     if (Object.keys(updateData).length === 0) {
-      res
-        .status(400)
-        .json({
-          error:
-            "At least one field (roleId, actorId, or performanceId) is required",
-        });
+      res.status(400).json({ error: "No fields to update" });
       return;
     }
 
@@ -248,6 +244,45 @@ async function deleteCastingHandler(
     res.status(200).json({ message: "Casting deleted successfully" });
   } catch (error) {
     console.error("Error in deleteCastingHandler:", error);
+    res.status(500).json({ error: SERVER_ERROR });
+  }
+}
+
+async function verifyCastingHandler(
+  req: Request<{ id: string }>,
+  res: Response
+) {
+  const { id } = req.params;
+  const validator = new Validator();
+
+  try {
+    validator.check(!!id, "id", "is required");
+    if (id) {
+      validator.check(validateUuid(id), "id", "must be a valid UUID");
+    }
+
+    if (!validator.valid) {
+      res.status(400).json({ errors: validator.errors });
+      return;
+    }
+
+    const existingCasting = await db.query.CastingTable.findFirst({
+      where: eq(CastingTable.id, id),
+    });
+
+    if (!existingCasting) {
+      res.status(404).json({ error: "Casting not found" });
+      return;
+    }
+
+    await db
+      .update(CastingTable)
+      .set({ verified: true })
+      .where(eq(CastingTable.id, id));
+
+    res.status(200).json({ message: "Casting verified successfully" });
+  } catch (error) {
+    console.error("Error in verifyCastingHandler:", error);
     res.status(500).json({ error: SERVER_ERROR });
   }
 }

--- a/src/v2/routes/musicals.ts
+++ b/src/v2/routes/musicals.ts
@@ -51,13 +51,14 @@ type CreateMusicalBodyParams = {
   composer: string;
   lyricist: string;
   title: string;
+  posterUrl?: string;
 };
 
 async function createMusicalHandler(
   req: Request<{}, {}, CreateMusicalBodyParams>,
   res: Response
 ) {
-  const { composer, lyricist, title } = req.body;
+  const { composer, lyricist, title, posterUrl } = req.body;
   const validator = new Validator();
 
   try {
@@ -72,7 +73,7 @@ async function createMusicalHandler(
 
     const [newMusical] = await db
       .insert(MusicalTable)
-      .values({ composer, lyricist, title })
+      .values({ composer, lyricist, title, posterUrl })
       .returning({ id: MusicalTable.id });
 
     if (!newMusical) {
@@ -132,6 +133,7 @@ type UpdateMusicalBodyParams = {
   composer?: string;
   lyricist?: string;
   title?: string;
+  posterUrl?: string;
 };
 
 async function updateMusicalHandler(
@@ -139,7 +141,7 @@ async function updateMusicalHandler(
   res: Response
 ) {
   const id = req.params.id;
-  const { composer, lyricist, title } = req.body;
+  const { composer, lyricist, title, posterUrl } = req.body;
   const validator = new Validator();
 
   try {
@@ -157,18 +159,18 @@ async function updateMusicalHandler(
       composer: string;
       lyricist: string;
       title: string;
+      posterUrl: string;
     }> = {};
     if (composer) updateData.composer = composer;
     if (lyricist) updateData.lyricist = lyricist;
     if (title) updateData.title = title;
+    if (posterUrl !== undefined) updateData.posterUrl = posterUrl;
 
     if (Object.keys(updateData).length === 0) {
-      res
-        .status(400)
-        .json({
-          error:
-            "At least one field (composer, lyricist, or title) is required",
-        });
+      res.status(400).json({
+        error:
+          "At least one field (composer, lyricist, title, or posterUrl) is required",
+      });
       return;
     }
 

--- a/src/v2/routes/performances.ts
+++ b/src/v2/routes/performances.ts
@@ -42,6 +42,7 @@ async function getAllPerformancesHandler(req: Request, res: Response) {
 }
 type CreatePerformanceBodyParams = {
   musicalId: string;
+  date?: string;
   notes?: string;
   posterUrl?: string;
 };
@@ -50,7 +51,7 @@ async function createPerformanceHandler(
   req: Request<{}, {}, CreatePerformanceBodyParams>,
   res: Response
 ) {
-  const { musicalId, notes, posterUrl } = req.body;
+  const { musicalId, date, notes, posterUrl } = req.body;
   const userId = req.user?.id;
   const validator = new Validator();
 
@@ -75,6 +76,7 @@ async function createPerformanceHandler(
       .values({
         musicalId,
         userId: userId!,
+        date: date ? new Date(date) : null,
         notes: notes || null,
         posterUrl: posterUrl || null,
       })
@@ -142,6 +144,7 @@ async function getPerformanceByIdHandler(
 
 type UpdatePerformanceBodyParams = {
   musicalId?: string;
+  date?: string;
   notes?: string;
   posterUrl?: string;
 };
@@ -151,7 +154,7 @@ async function updatePerformanceHandler(
   res: Response
 ) {
   const id = req.params.id;
-  const { musicalId, notes, posterUrl } = req.body;
+  const { musicalId, date, notes, posterUrl } = req.body;
   const userId = req.user?.id;
   const validator = new Validator();
 
@@ -191,17 +194,19 @@ async function updatePerformanceHandler(
 
     const updateData: Partial<{
       musicalId: string;
+      date: Date;
       notes: string;
       posterUrl: string;
     }> = {};
     if (musicalId) updateData.musicalId = musicalId;
+    if (date) updateData.date = new Date(date);
     if (notes !== undefined) updateData.notes = notes;
     if (posterUrl !== undefined) updateData.posterUrl = posterUrl;
 
     if (Object.keys(updateData).length === 0) {
       res.status(400).json({
         error:
-          "At least one field (musicalId, notes, or posterUrl) is required",
+          "At least one field (musicalId, date, notes, or posterUrl) is required",
       });
       return;
     }


### PR DESCRIPTION
Schema changes:
- Add posterUrl to Musical table and API endpoints
- Add date field to Performance table and PUT endpoint
- Add required performanceId to Casting table and API endpoints
- Remove verified field from Casting table and API endpoints
- Remove POST /casting/:id/verify endpoint

API changes:
- Musical POST/PUT now support posterUrl parameter
- Performance POST/PUT now support date parameter
- Casting POST now requires performanceId and returns only casting ID
- Casting PUT now supports performanceId parameter
- Casting GET endpoints no longer filter by verified status
- Removed casting verification endpoint

Migration: 0001_ordinary_human_cannonball.sql